### PR TITLE
fix(cli): improve missing build output error message

### DIFF
--- a/opensoul.mjs
+++ b/opensoul.mjs
@@ -52,5 +52,22 @@ if (await tryImport("./dist/entry.js")) {
 } else if (await tryImport("./dist/entry.mjs")) {
   // OK
 } else {
-  throw new Error("opensoul: missing dist/entry.(m)js (build output).");
+  console.error(`
+❌ OpenSoul build output not found.
+
+The CLI could not find:
+  dist/entry.js
+
+This usually means the project has not been built.
+
+Fix it by running:
+
+  pnpm install
+  pnpm build
+
+Then retry:
+
+  node opensoul.mjs
+`);
+  process.exit(1);
 }


### PR DESCRIPTION
## Summary

Improves the CLI error message shown when the build output (dist/entry.js) is missing during onboarding. 
Instead of throwing a generic error, the CLI now provides a clear explanation and actionable steps to fix the issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7

## Changes Made

- Replaced generic thrown error with a user-friendly error message
- Clearly explains that build output is missing
- Suggests running `pnpm install` and `pnpm build`
- Exits with proper status code after displaying guidance

## Checklist

- [x] My code follows the project's coding style
- [ ] I have run `pnpm check` and `pnpm test` locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings or errors
