### PR TITLE
fix: treat wildcard hosts as non-loopback in browser control

### DIFF
--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -20,11 +20,8 @@ export function isLoopbackHost(host: string) {
   return (
     h === "localhost" ||
     h === "127.0.0.1" ||
-    h === "0.0.0.0" ||
     h === "[::1]" ||
-    h === "::1" ||
-    h === "[::]" ||
-    h === "::"
+    h === "::1"
   );
 }
 

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -101,6 +101,20 @@ describe("browser config", () => {
     expect(profile?.cdpIsLoopback).toBe(false);
   });
 
+  it("treats wildcard CDP hosts as non-loopback", () => {
+    const ipv4Wildcard = resolveBrowserConfig({
+      cdpUrl: "http://0.0.0.0:9222",
+    });
+    expect(ipv4Wildcard.cdpIsLoopback).toBe(false);
+    expect(resolveProfile(ipv4Wildcard, "opensoul")?.cdpIsLoopback).toBe(false);
+
+    const ipv6Wildcard = resolveBrowserConfig({
+      cdpUrl: "http://[::]:9222",
+    });
+    expect(ipv6Wildcard.cdpIsLoopback).toBe(false);
+    expect(resolveProfile(ipv6Wildcard, "opensoul")?.cdpIsLoopback).toBe(false);
+  });
+
   it("supports explicit CDP URLs for the default profile", () => {
     const resolved = resolveBrowserConfig({
       cdpUrl: "http://example.com:9222",

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -47,11 +47,8 @@ function isLoopbackHost(host: string) {
   return (
     h === "localhost" ||
     h === "127.0.0.1" ||
-    h === "0.0.0.0" ||
     h === "[::1]" ||
-    h === "::1" ||
-    h === "[::]" ||
-    h === "::"
+    h === "::1"
   );
 }
 

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -144,6 +144,20 @@ describe("chrome extension relay server", () => {
     }
   });
 
+  it("rejects wildcard hosts for relay bootstrap", async () => {
+    await expect(
+      ensureChromeExtensionRelayServer({
+        cdpUrl: `http://0.0.0.0:${await getFreePort()}`,
+      }),
+    ).rejects.toThrow(/requires loopback cdpUrl host/i);
+
+    await expect(
+      ensureChromeExtensionRelayServer({
+        cdpUrl: `http://[::]:${await getFreePort()}`,
+      }),
+    ).rejects.toThrow(/requires loopback cdpUrl host/i);
+  });
+
   it("advertises CDP WS only when extension is connected", async () => {
     const port = await getFreePort();
     cdpUrl = `http://127.0.0.1:${port}`;

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -106,11 +106,8 @@ function isLoopbackHost(host: string) {
   return (
     h === "localhost" ||
     h === "127.0.0.1" ||
-    h === "0.0.0.0" ||
     h === "[::1]" ||
-    h === "::1" ||
-    h === "[::]" ||
-    h === "::"
+    h === "::1"
   );
 }
 


### PR DESCRIPTION
## Summary
- classify wildcard hosts (0.0.0.0, [::], ::) as non-loopback in browser host checks
- keep loopback detection limited to localhost, 127.0.0.1, and ::1
- add regression tests for wildcard host handling in browser config and extension relay

## Why
Wildcard bind addresses should not be treated as loopback/trusted endpoints. This closes a trust-boundary mistake in browser control host classification.

## Validation
- corepack pnpm vitest src/browser/config.test.ts src/browser/extension-relay.test.ts
